### PR TITLE
Export getfilestorage

### DIFF
--- a/src/fileStorage/__tests__/fileStorage.test.js
+++ b/src/fileStorage/__tests__/fileStorage.test.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const sharp = require('sharp')
 
-const fileStorage = require('../index')
+const { fileStorage } = require('../index')
 const FileStorageConstructor = require('../FileStorage')
 const tempFolderPath = require('../../utils/tempFolderPath')
 const request = require('../../utils/request')

--- a/src/fileStorage/helpers/fileStorage.js
+++ b/src/fileStorage/helpers/fileStorage.js
@@ -1,0 +1,13 @@
+/* eslint-disable max-classes-per-file */
+
+const config = require('config')
+
+const FileStorage = require('../FileStorage')
+const FileStorageNoop = require('../FileStorageNoop')
+
+const exportedClass =
+  config.has('useFileStorage') && config.get('useFileStorage')
+    ? new FileStorage()
+    : new FileStorageNoop()
+
+module.exports = exportedClass

--- a/src/fileStorage/helpers/getFileStorage.js
+++ b/src/fileStorage/helpers/getFileStorage.js
@@ -1,0 +1,9 @@
+const fileStorage = require('./fileStorage')
+const FileStorageConstructor = require('../FileStorage')
+
+const getFileStorage = connectionConfig => {
+  if (!connectionConfig) return fileStorage
+  return new FileStorageConstructor(connectionConfig)
+}
+
+module.exports = getFileStorage

--- a/src/fileStorage/index.js
+++ b/src/fileStorage/index.js
@@ -1,9 +1,5 @@
-/* eslint-disable max-classes-per-file */
-
-const config = require('config')
-
-const FileStorage = require('./FileStorage')
-const FileStorageNoop = require('./FileStorageNoop')
+const fileStorage = require('./helpers/fileStorage')
+const getFileStorage = require('./helpers/getFileStorage')
 
 /**
  * PREVIOUSLY EXPORTED FUNCTIONS
@@ -19,9 +15,4 @@ const FileStorageNoop = require('./FileStorageNoop')
 //   list,
 // }
 
-const exportedClass =
-  config.has('useFileStorage') && config.get('useFileStorage')
-    ? new FileStorage()
-    : new FileStorageNoop()
-
-module.exports = exportedClass
+module.exports = { fileStorage, getFileStorage }

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const {
 const modelJsonSchemaTypes = require('./models/_helpers/types')
 const clearDb = require('./models/_helpers/clearDb')
 const tempFolderPath = require('./utils/tempFolderPath')
-const fileStorage = require('./fileStorage')
+const { fileStorage, getFileStorage } = require('./fileStorage')
 
 const WaxToDocxConverter = require('./services/docx/docx.service')
 
@@ -77,6 +77,7 @@ module.exports = {
   migrationManager,
   subscriptionManager,
   fileStorage,
+  getFileStorage,
 
   /* UTILS */
   isEnvVariableTrue,

--- a/src/models/file/file.controller.js
+++ b/src/models/file/file.controller.js
@@ -19,7 +19,13 @@ const createFile = async (
   options = {},
 ) => {
   try {
-    const { trx, forceObjectKeyValue, s3, public: isPublic } = options
+    const {
+      trx,
+      forceObjectKeyValue,
+      s3,
+      public: isPublic,
+      referenceId = null,
+    } = options
 
     const storage = getFileStorage(s3)
 
@@ -36,6 +42,7 @@ const createFile = async (
         tags,
         objectId,
         storedObjects,
+        referenceId,
       },
       { trx },
     )

--- a/src/models/file/file.controller.js
+++ b/src/models/file/file.controller.js
@@ -3,17 +3,11 @@ const logger = require('../../logger')
 const File = require('./file.model')
 const useTransaction = require('../useTransaction')
 
-const fileStorage = require('../../fileStorage')
-const FileStorageConstructor = require('../../fileStorage/FileStorage')
+const { getFileStorage } = require('../../fileStorage')
 
 const {
   labels: { FILE_CONTROLLER },
 } = require('./constants')
-
-const getStorage = connectionConfig => {
-  if (!connectionConfig) return fileStorage
-  return new FileStorageConstructor(connectionConfig)
-}
 
 const createFile = async (
   fileStream,
@@ -27,7 +21,7 @@ const createFile = async (
   try {
     const { trx, forceObjectKeyValue, s3, public: isPublic } = options
 
-    const storage = getStorage(s3)
+    const storage = getFileStorage(s3)
 
     const storedObjects = await storage.upload(fileStream, name, {
       forceObjectKeyValue,
@@ -55,7 +49,7 @@ const deleteFiles = async (ids, removeFromFileServer = true, options = {}) => {
   try {
     const { trx, s3 } = options
 
-    const storage = getStorage(s3)
+    const storage = getFileStorage(s3)
 
     logger.info(
       `${FILE_CONTROLLER} deleteFiles: deleting files with ids ${ids}`,

--- a/src/models/file/migrations/1698750314-add-full-quality-converted-object-to-storedobjects.js
+++ b/src/models/file/migrations/1698750314-add-full-quality-converted-object-to-storedobjects.js
@@ -16,7 +16,7 @@ const { Upload } = require('@aws-sdk/lib-storage')
 const useTransaction = require('../../useTransaction')
 const File = require('../file.model')
 const tempFolderPath = require('../../../utils/tempFolderPath')
-const fileStorage = require('../../../fileStorage')
+const { fileStorage } = require('../../../fileStorage')
 
 const imageSizeConversionMapper = {
   tiff: {

--- a/src/startup/checkConnections.js
+++ b/src/startup/checkConnections.js
@@ -2,7 +2,7 @@ const config = require('config')
 
 const db = require('../db/db')
 const { logTask, logTaskItem, logErrorTask } = require('../logger/internals')
-const fileStorage = require('../fileStorage')
+const { fileStorage } = require('../fileStorage')
 
 const sleep = ms =>
   new Promise(resolve => {


### PR DESCRIPTION
Related to [Kotahi issue #1705](https://gitlab.coko.foundation/kotahi/kotahi/-/issues/1705)

This PR:
* exports `getFileStorage` to dynamically provide s3 settings for multiple buckets
* makes optional use of `referenceId` for file uploads